### PR TITLE
Missing a single / crashe the URL

### DIFF
--- a/knowledge_base/templates/generators/help_article.html
+++ b/knowledge_base/templates/generators/help_article.html
@@ -9,7 +9,7 @@
 	<div class="longform" itemprop="articleBody">
 	{{ content }}
 	</div>
-	<p><a href="{{ parent_website_route }}">{{ _("More articles on {0}").format(category) }}</a></p>
+	<p><a href="/{{ parent_website_route }}">{{ _("More articles on {0}").format(category) }}</a></p>
 </article>
 <div class="help-article-comments">
 	<h3>Comments</h3>


### PR DESCRIPTION
In template is missing a single '/' so the browser maps "https://kb.frappe.io/kb/app-development/kb/app-development" instead of "https://kb.frappe.io/kb/app-development"