### PR TITLE
Removed import

### DIFF
--- a/knowledge_base/knowledge_base/doctype/help_article/help_article.py
+++ b/knowledge_base/knowledge_base/doctype/help_article/help_article.py
@@ -7,7 +7,6 @@ from frappe.website.website_generator import WebsiteGenerator
 from frappe.utils import is_markdown, markdown
 from frappe.website.utils import get_comment_list
 from knowledge_base.utils import get_level_class, get_category_sidebar, clear_cache
-from frappe.templates.pages.list import get_list
 from frappe import _
 
 class HelpArticle(WebsiteGenerator):


### PR DESCRIPTION
I removed

`from frappe.templates.pages.list import get_list`

Now the module is working fine again.
